### PR TITLE
fix: allow direct push to main for XCFramework publishing

### DIFF
--- a/otterdog/eclipse-keyple.jsonnet
+++ b/otterdog/eclipse-keyple.jsonnet
@@ -458,13 +458,6 @@ orgs.newOrg('iot.keyple', 'eclipse-keyple') {
       workflows+: {
         default_workflow_permissions: "write",
       },
-      branch_protection_rules: [
-        orgs.newBranchProtectionRule(thisRepo.default_branch) {
-          required_approving_review_count: 1,
-          requires_status_checks: false,
-          requires_strict_status_checks: true,
-        },
-      ],
     },
     orgs.newRepo('keyple-integration-java-test') {
       allow_merge_commit: true,


### PR DESCRIPTION
The 'main' branch protection rule for the 'keyple-interop-ios-xcframework' repository is modified to **remove the requirement for a Pull Request**.

Rationale:
This change is necessary to enable the automated CI/CD workflow to perform required actions (version bump, release attachment, etc.) by directly pushing to 'main'.

Due to the technical limitations of using the default GITHUB_TOKEN for such critical commit operations, the PR requirement is permanently lifted for this specific automation flow, which is considered essential for the automated release of the XCFramework.